### PR TITLE
Backend game nginx setting

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,8 @@
 POSTGRES_DB=postgres
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
 
 # Django settings
 DEBUG=True

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 
 from pathlib import Path
 
+import os
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -25,7 +27,7 @@ SECRET_KEY = 'django-insecure-zfc8_i1(e)xhnm6rk+g+hm1of9bwr$j+h_3)9vt3q_r#m1_l5-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['0.0.0.0', 'localhost']
+ALLOWED_HOSTS = ["localhost", "127.0.0.1", "django"]
 
 
 # Application definition
@@ -100,11 +102,11 @@ WSGI_APPLICATION = 'config.wsgi.application'
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "postgres",
-        "USER": "postgres",
-        "PASSWORD": "postgres",
-        "HOST": "db",
-        "PORT": "5432",
+        "NAME": os.getenv("POSTGRES_DB"),
+        "USER": os.getenv("POSTGRES_USER"),
+        "PASSWORD": os.getenv("POSTGRES_PASSWORD"),
+        "HOST": os.getenv("POSTGRES_HOST"),
+        "PORT": os.getenv("POSTGRES_PORT"),
     }
 }
 
@@ -140,6 +142,7 @@ USE_I18N = True
 
 USE_TZ = True
 
+# APPEND_SLASH = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -142,8 +142,6 @@ USE_I18N = True
 
 USE_TZ = True
 
-# APPEND_SLASH = True
-
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -14,9 +14,9 @@ router.register(r'tournaments', TournamentViewSet, basename='tournament')
 
 urlpatterns = [
     # API 스키마 생성 엔드포인트
-    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('schema/', SpectacularAPIView.as_view(), name='schema'),
     # Swagger UI 뷰
-    path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     path('', include(router.urls)),
     path('admin/', admin.site.urls),
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,15 @@ services:
     # expose: # 개발완료시 해당 주석 해제 후 ports 제거 필요합니다
     #   - "8000"
     ports: 
-      - "8000:8000
+      - 8000:8000
     volumes:
       - type: bind
         source: ./backend
         target: /app
+    env_file:
+      ./.env
     environment:
-      - ALLOWED_HOSTS=${ALLOWED_HOSTS}
+      - POSTGRES_HOST=${POSTGRES_HOST}
     depends_on:
       - db
 
@@ -26,7 +28,7 @@ services:
     expose:
       - "5432"
     container_name: postgres
-    env_file: .env
+    env_file: ./.env
 
   nginx:
     build: nginx/

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,10 +27,6 @@ http {
 			try_files $uri /index.html;
 		}
 
-
-		location /api/ {
-			
-		}
 		# api
 		location ~ ^/api/(.*)$ {
 			proxy_pass http://django:8000/$1$is_args$args/;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -25,16 +25,33 @@ http {
 		location / {
 			root /usr/share/nginx/html;
 			try_files $uri /index.html;
-			# try_files $uri $uri/ = 404;
 		}
 
+
+		location /api/ {
+			
+		}
 		# api
-		# location /api/ {
-		# 	proxy_pass http://django:8000;
-		# 	proxy_http_version 1.1;
-		# 	proxy_set_header Upgrade $http_upgrade;
-		# 	proxy_set_header Connection "upgrade";
-		# 	proxy_read_timeout 86400;
-		# }
+		location ~ ^/api/(.*)$ {
+			proxy_pass http://django:8000/$1$is_args$args/;
+			proxy_http_version 1.1;
+
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection "upgrade";
+			proxy_set_header Host $http_host;
+			proxy_set_header X-Real-IP $remote_addr;
+			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+			proxy_set_header X-Forwarded-Proto $scheme;
+			proxy_set_header Referer $http_referer;
+		}
+
+		# websocket
+		location /ws/ {
+			proxy_pass http://django:8000;
+			proxy_http_version 1.1;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection "upgrade";
+			proxy_read_timeout 86400;
+		}
 	}
 }


### PR DESCRIPTION
- nginx 설정 변경
  - api도 처리할 수 있도록 api location block 설정 완료
  - 끝에 '/' 없이 요청해야함
  - 웹소켓 통신을 위한 ws location block 설정
 
- django project의 settings.py 수정
  - allowed hosts에 api 처리를 위한 "django" 추가
  - DATABASES 설정을 환경 변수(.env) 에서 가져오도록 처리

- swagger를 보기 위해 8000번 포트로 접속해야함
  - localhost:8000/docs/ 로 접속하면 swagger 나옴