### PR TITLE
Backend user login API refactoring / Django superuser create

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -3,5 +3,7 @@
 
 python manage.py makemigrations
 python manage.py migrate
+python manage.py createsuperuser --no-input --username $DJANGO_SUPERUSER_USERNAME --email $DJANGO_SUPERUSER_EMAIL || true
+python manage.py shell -c "from users.models import User; user=User.objects.get(username='$DJANGO_SUPERUSER_USERNAME'); user.set_password('$DJANGO_SUPERUSER_PASSWORD'); user.save()"
 
 exec python manage.py runserver 0.0.0.0:8000

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from django.contrib.auth import authenticate
 from .models import User
 
 class UserSerializer(serializers.ModelSerializer):
@@ -28,12 +29,10 @@ class LoginSerializer(serializers.Serializer):
     password = serializers.CharField(help_text="Password for the user login.")
 
     def validate(self, data):
-        user = User.objects.filter(username=data['username']).first()
+        user = authenticate(username=data['username'], password=data['password'])
         if user is None:
             raise serializers.ValidationError("User not found.")
-        if not user.check_password(data['password']):
-            raise serializers.ValidationError("Invalid password.")
-        return data
+        return {'user': user}
 
 class SignUpSerializer(serializers.ModelSerializer):
     class Meta:

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -120,21 +120,18 @@ class UserViewSet(viewsets.ViewSet):
         responses={
             200: OpenApiResponse(description="User logged in successfully"),
             400: OpenApiResponse(description="Bad request"),
-            401: OpenApiResponse(description="Unauthorized"),
         },
         tags=["User"]
     )
     @action(detail=False, methods=['post'])
     def login(self, request):
-        serializer = LoginSerializer(data=request.data)
-        if serializer.is_valid():
-            # print(serializer.validated_data['username'], serializer.validated_data['password'])
-            user = authenticate(username=serializer.validated_data['username'], password=serializer.validated_data['password'])
-            if user is not None:
+        if request.user.is_anonymous:
+            serializer = LoginSerializer(data=request.data)
+            if serializer.is_valid():
+                user = serializer.validated_data['user']
                 login(request, user)
                 return Response(status=status.HTTP_200_OK)
-            return Response(serializer.errors, status=status.HTTP_401_UNAUTHORIZED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        return Response(status=status.HTTP_400_BAD_REQUEST)
 
     @extend_schema(
         summary="User logout",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     env_file:
       ./.env
     environment:
-      - ALLOWED_HOSTS=${ALLOWED_HOSTS}
+      - POSTGRES_HOST=${POSTGRES_HOST}
       - DJANGO_SUPERUSER_USERNAME=admin
       - DJANGO_SUPERUSER_EMAIL=admin@example.com
       - DJANGO_SUPERUSER_PASSWORD=1234

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,10 @@ services:
     env_file:
       ./.env
     environment:
-      - POSTGRES_HOST=${POSTGRES_HOST}
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS}
+      - DJANGO_SUPERUSER_USERNAME=admin
+      - DJANGO_SUPERUSER_EMAIL=admin@example.com
+      - DJANGO_SUPERUSER_PASSWORD=1234
     depends_on:
       - db
 


### PR DESCRIPTION
- Login API 를 리팩토링 했습니다.
  - authenticate 를 serializer의 validate 함수 내에서 수행하도록 만들었습니다.
  - 중복 로그인 요청시 BAD_REQUEST 를 반환하도록 처리했습니다.

- Django 슈퍼유저를 자동생성하도록 변경했습니다.
   - docker-compose.yml 에서 django 부분의 environment 에서 id / pw 를 확인할 수 있습니다.
   - id : admin / pw : 1234 입니다.