### PR TITLE
games 테이블(model) 및 users/self api response schema 변경

### DIFF
--- a/backend/games/models.py
+++ b/backend/games/models.py
@@ -13,7 +13,7 @@ class Match(models.Model):
 
     TYPE_CHOICES = [
         ('tournament', '토너먼트 경기'),
-        ('match', '1대1경기'),
+        ('single', '1대1경기'),
     ]
 
     match_username1 = models.ForeignKey(

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -696,11 +696,13 @@ class UserViewSet(viewsets.ViewSet):
                     ],
                     'matches': [
                         {
+                            'user1_name': match.match_username1.username,
+                            'user2_name': match.match_username2.username,
                             'match_result': match.match_result,
                             'match_start_time': match.match_start_time,
                             'match_end_time': match.match_end_time,
-                            'username1_grade': match.username1_grade,
-                            'username2_grade': match.username2_grade,
+                            'user1_grade': match.username1_grade,
+                            'user2_grade': match.username2_grade,
                             'match_type': match.match_type
                         } 
                         for match in matches.order_by('-match_end_time')[:5]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -497,11 +497,13 @@ class UserViewSet(viewsets.ViewSet):
                             "profile_img": friend_user.profile_img,
                             "matches": [
                                 {
+                                    'user1_name': match.match_username1.username,
+                                    'user2_name': match.match_username2.username,
                                     'match_result': match.match_result,
                                     'match_start_time': match.match_start_time,
                                     'match_end_time': match.match_end_time,
-                                    'username1_grade': match.username1_grade,
-                                    'username2_grade': match.username2_grade,
+                                    'user1_grade': match.username1_grade,
+                                    'user2_grade': match.username2_grade,
                                     'match_type': match.match_type
                                 } 
                                 for match in matches.order_by('-match_end_time')[:5]


### PR DESCRIPTION
0. #24 를 해결합니다.
1. games 테이블(model)에서 `1:1`과 `토너먼트`를
    - frontend 에서는 `single`, `tournament`
    - backend 에서는 `match`, `tournament`
  로 라벨링을 하고 있어서 데이터 렌더링에 오류가 있었습니다. 제가 보기에는 `single`, `tournament`가 더 직관적이어서 backend label를 수정했습니다.
2. `users/self` api response에 각 유저들의 이름이 미포함되어있어, 누가 나인지, 누구랑 대결했는지 모르는 이슈가 있었습니다. 필드를 추가하여 해결했습니다.
3. username1_grade 이름이 어색해서 user1_grade 로 수정했습니다.

+) `self/friends`에서도 2번 문제가 있을 것 같은데, 추가로 수정할까요?