### PR TITLE
Backend matchdata fix and Add docker volume for db

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -4,7 +4,6 @@ from .models import User
 from friends.models import Friend
 from games.models import Match
 from django.contrib.sessions.models import Session
-from drf_spectacular.utils import extend_schema_field
 
 
 class LoginSerializer(serializers.Serializer):

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -4,6 +4,8 @@ from .models import User
 from friends.models import Friend
 from games.models import Match
 from django.contrib.sessions.models import Session
+from drf_spectacular.utils import extend_schema_field
+
 
 class LoginSerializer(serializers.Serializer):
     username = serializers.CharField(max_length=150, required=True)
@@ -293,12 +295,31 @@ class DeleteFriendshipSerializer(serializers.Serializer):
         return old_friendship
 
 class MatchResponseSerializer(serializers.ModelSerializer):
+    user1_name = serializers.ReadOnlyField(source='match_username1.username')
+    user2_name = serializers.ReadOnlyField(source='match_username2.username')
+    user1_profile_img = serializers.ReadOnlyField(source='match_username1.profile_img')
+    user2_profile_img = serializers.ReadOnlyField(source='match_username2.profile_img')
+
     class Meta:
         model = Match
-        fields = ['match_result', 'match_start_time', 'match_end_time', 'username1_grade', 'username2_grade', 'match_type']
+        fields = ['user1_name', 'user2_name', 'user1_profile_img', 'user2_profile_img', 'match_result', 'match_start_time', 'match_end_time', 'username1_grade', 'username2_grade', 'match_type']
+
+class MacroTextSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['macrotext1', 'macrotext2', 'macrotext3', 'macrotext4', 'macrotext5']
+
 class RetrieveFriendSerializer(serializers.ModelSerializer):
     matches = MatchResponseSerializer(many=True, read_only=True)
 
     class Meta:
         model = User
-        fields = ['username', 'status_msg', 'status', 'profile_img', 'matches']
+        fields = ['username', 'status_msg', 'status', 'exp', 'win_cnt', 'lose_cnt', 'profile_img', 'matches']
+
+class RetrieveUserSerializer(serializers.ModelSerializer):
+    matches = MatchResponseSerializer(many=True, read_only=True)
+    macrotext = MacroTextSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = User
+        fields = ['exp', 'profile_img', 'win_cnt', 'lose_cnt', 'status_msg', 'macrotext', 'matches']

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -17,7 +17,8 @@ from .serializers import (
     DeleteFriendshipSerializer,
     RetrieveFriendSerializer,
     RetrieveSearchUserSerializer,
-    RetrieveSearchUserResponseSerializer
+    RetrieveSearchUserResponseSerializer,
+    RetrieveUserSerializer
 )
 
 from django.views.decorators.csrf import csrf_exempt
@@ -494,11 +495,16 @@ class UserViewSet(viewsets.ViewSet):
                             "username": friend_user.username,
                             "status_msg": friend_user.status_msg,
                             "status": friend_user.status,
+                            "exp": friend_user.exp,
+                            "win_cnt": friend_user.win_cnt,
+                            "lose_cnt": friend_user.lose_cnt,
                             "profile_img": friend_user.profile_img,
                             "matches": [
                                 {
                                     'user1_name': match.match_username1.username,
                                     'user2_name': match.match_username2.username,
+                                    'user1_profile_img': match.match_username1.profile_img,
+                                    'user2_profile_img': match.match_username2.profile_img,
                                     'match_result': match.match_result,
                                     'match_start_time': match.match_start_time,
                                     'match_end_time': match.match_end_time,
@@ -551,28 +557,8 @@ class UserViewSet(viewsets.ViewSet):
         description="Get the user's details through authentication",
         responses={
             200: OpenApiResponse(
-                response=OpenApiTypes.OBJECT,
+                response=RetrieveUserSerializer,
                 description="Successfully obtaining user details",
-                examples=[
-                    OpenApiExample(
-                        name="userinfo details",
-                        value={
-                            'exp': 'int',
-                            'profile_img': 'int',
-                            'win_cnt': 'int',
-                            'lose_cnt': 'int',
-                            'status_msg': 'string',
-                            'macrotext': [
-                                'string',
-                                'string',
-                                'string',
-                                'string',
-                                'string'
-                            ]
-                        },
-                        media_type='application/json'
-                    )
-                ]
             ),
             403: OpenApiResponse(
                 response=OpenApiTypes.OBJECT,
@@ -700,6 +686,8 @@ class UserViewSet(viewsets.ViewSet):
                         {
                             'user1_name': match.match_username1.username,
                             'user2_name': match.match_username2.username,
+                            'user1_profile_img': match.match_username1.profile_img,
+                            'user2_profile_img': match.match_username2.profile_img,
                             'match_result': match.match_result,
                             'match_start_time': match.match_start_time,
                             'match_end_time': match.match_end_time,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,7 @@ services:
       - type: bind
         source: ./backend
         target: /app
-    env_file:
-      ./.env
+    env_file: ./.env
     environment:
       - POSTGRES_HOST=${POSTGRES_HOST}
       - DJANGO_SUPERUSER_USERNAME=admin
@@ -30,6 +29,8 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     expose:
       - "5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
     container_name: postgres
     env_file: ./.env
 
@@ -44,3 +45,8 @@ services:
     restart: always
     depends_on:
       - django
+
+volumes:
+  db_data:
+    name: db_data
+    driver: local


### PR DESCRIPTION
### 수정사항

- GET users/self API의 matches 항목에 user1_profile_img, user2_profile_img 항목이 추가되었습니다.
- GET users/self/friend API에서 exp, win_cnt, lose_cnt 와 matches 항목의 user1_profile_img, user2_profile_img 항목이 추가되었습니다.
- frontend 에서 효율적인 개발을 위해 db 컨테이너의 docker volume 을 추가했습니다
- docker volume 의 이름은 db_data 이며, 해당 볼륨을 지우지 않는 한 db에 생성한 데이터들은 삭제되지 않습니다.