### PR TITLE
Add retrieve match history api

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -11,7 +11,7 @@ from django.contrib import admin
 router = DefaultRouter()
 router.register(r'users', UserViewSet, basename='user')
 router.register(r'friends', FriendViewSet, basename='friend')
-router.register(r'matchs', MatchViewSet, basename='match')
+router.register(r'matches', MatchViewSet, basename='match')
 router.register(r'oauth', OAuthViewSet, basename='oauth')
 
 urlpatterns = [

--- a/backend/games/urls.py
+++ b/backend/games/urls.py
@@ -1,10 +1,10 @@
-from django.urls import path, include
+from django.urls import path, include, re_path
 from rest_framework.routers import DefaultRouter
 from .views import MatchViewSet
 
 router = DefaultRouter()
-router.register(r'', MatchViewSet, basename='match')
+router.register(r'', MatchViewSet)
 
 urlpatterns = [
-    path('', include(router.urls)),
+    path('', include(router.urls))
 ]

--- a/backend/games/views.py
+++ b/backend/games/views.py
@@ -1,10 +1,99 @@
-from rest_framework import viewsets
+from rest_framework import viewsets, status
 from rest_framework.response import Response
-from rest_framework import status
-import uuid
+from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiTypes, OpenApiExample, OpenApiParameter
+
+from django.db.models import Q
+from games.models import Match
 
 class MatchViewSet(viewsets.ViewSet):
+    
     """
     A ViewSet for managing matches.
     """
-    pass
+
+    lookup_field = 'username'
+
+##### READ #####
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name='count',
+                description='Retrieve user match history by username and count',
+                required=False,
+                type=int
+            ),
+        ],
+        summary="Search match history",
+        description="Find match history based on username and count\n\
+                    default is count=5",
+        responses={
+            200: OpenApiResponse(
+                description="Successfully retrieve match history"
+            ),
+            403: OpenApiResponse(
+                response=OpenApiTypes.OBJECT,
+                description="Don't have permission to access the data",
+                examples=[
+                    OpenApiExample(
+                        name="Not logged in",
+                        value={ "error": "로그인 상태가 아닙니다" },
+                        media_type='application/json'
+                    )
+                ]
+            ),
+            404: OpenApiResponse(
+                response=OpenApiTypes.OBJECT,
+                description="Not Found",
+                examples=[
+                    OpenApiExample(
+                        name="User find fail",
+                        value={ "error": "일치하는 유저가 없습니다" },
+                        media_type='application/json'
+                    )
+                ]
+            ),
+            500: OpenApiResponse(
+                response=OpenApiTypes.OBJECT,
+                description="Internal server error",
+                examples=[
+                    OpenApiExample(
+                        name="undefined behavior",
+                        value={ "error": "시스템 에러 메세지가 출력됩니다" },
+                        media_type='application/json'
+                    )
+                ]
+            )
+        },
+        tags=["Match"]
+    )
+    def retrieve(self, request, username=None):
+        try:
+            user = request.user
+            matches = Match.objects.filter((Q(match_username1=user) | Q(match_username2=user)) & ~Q(match_result='pending_result'))
+            matches_data = {
+                "matches": [
+                    {
+                        'user1_name': match.match_username1.username,
+                        'user2_name': match.match_username2.username,
+                        'user1_profile_img': match.match_username1.profile_img,
+                        'user2_profile_img': match.match_username2.profile_img,
+                        'match_result': match.match_result,
+                        'match_start_time': match.match_start_time,
+                        'match_end_time': match.match_end_time,
+                        'user1_grade': match.username1_grade,
+                        'user2_grade': match.username2_grade,
+                        'match_type': match.match_type
+                    } 
+                    for match in matches.order_by('-match_end_time')[:5]
+                ]
+            }
+            return Response(matches_data, status=status.HTTP_200_OK)
+        except ValueError as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except PermissionError as e:
+            return Response({"error": str(e)}, status=status.HTTP_403_FORBIDDEN)
+        except LookupError as e:
+            return Response({"error": str(e)}, status=status.HTTP_404_NOT_FOUND)
+        except Exception as e:
+            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    # username을 기반으로 match history를 찾는 API


### PR DESCRIPTION
## 수정사항
- microservice 설계를 위해 match table 에서 game_history 를 가져오는 api 를 임시로 구현하였습니다.

## 주의사항
- 임시로 구현된 api 이기 때문에 error 처리가 하나도 되어있지 않은 상태입니다.
- 따라서 문제 발생시 500 internal server error를 뱉을 가능성이 높습니다.
- count 파라미터 또한 구현이 되지 않은 상태라 값이 얼마든 5개의 match_history 를 반환합니다.

## 요구사항
- 현재 Frontend 에서 해당 api 를 통해 match_history 를 받아오는 걸로 변경이 필요합니다.
- users/self , users/self/friend 의 get 요청을 통해 match data를 받아오는 로직이 이에 해당합니다.

## 사용방법
- matches/{username}?count= 의 형태로 동작합니다.
- count 의 경우 몇개의 match 기록을 가져올지 지정할 수 있습니다.
- 아무것도 입력하지 않으면, 기본적으로 5개의 최신 경기 기록을 가져옵니다.
