### PR TITLE
Add retrieve multiple user match history api

### DIFF
--- a/backend/games/views.py
+++ b/backend/games/views.py
@@ -1,6 +1,8 @@
 from rest_framework import viewsets, status
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiTypes, OpenApiExample, OpenApiParameter
+from friends.models import Friend
 
 from django.db.models import Q
 from games.models import Match
@@ -23,7 +25,7 @@ class MatchViewSet(viewsets.ViewSet):
                 type=int
             ),
         ],
-        summary="Search match history",
+        summary="Search user match history",
         description="Find match history based on username and count\n\
                     default is count=5",
         responses={
@@ -88,6 +90,98 @@ class MatchViewSet(viewsets.ViewSet):
                 ]
             }
             return Response(matches_data, status=status.HTTP_200_OK)
+        except ValueError as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except PermissionError as e:
+            return Response({"error": str(e)}, status=status.HTTP_403_FORBIDDEN)
+        except LookupError as e:
+            return Response({"error": str(e)}, status=status.HTTP_404_NOT_FOUND)
+        except Exception as e:
+            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    # username을 기반으로 match history를 찾는 API
+
+    @extend_schema(
+        summary="Search users match history",
+        description="Find match history based on username",
+        responses={
+            200: OpenApiResponse(
+                description="Successfully retrieve match history"
+            ),
+            403: OpenApiResponse(
+                response=OpenApiTypes.OBJECT,
+                description="Don't have permission to access the data",
+                examples=[
+                    OpenApiExample(
+                        name="Not logged in",
+                        value={ "error": "로그인 상태가 아닙니다" },
+                        media_type='application/json'
+                    )
+                ]
+            ),
+            404: OpenApiResponse(
+                response=OpenApiTypes.OBJECT,
+                description="Not Found",
+                examples=[
+                    OpenApiExample(
+                        name="User find fail",
+                        value={ "error": "일치하는 유저가 없습니다" },
+                        media_type='application/json'
+                    )
+                ]
+            ),
+            500: OpenApiResponse(
+                response=OpenApiTypes.OBJECT,
+                description="Internal server error",
+                examples=[
+                    OpenApiExample(
+                        name="undefined behavior",
+                        value={ "error": "시스템 에러 메세지가 출력됩니다" },
+                        media_type='application/json'
+                    )
+                ]
+            )
+        },
+        tags=["Match"]
+    )
+    @action(detail=False, methods=['post'], url_path='search')
+    def search(self, request):
+        try:
+            user = request.user
+            friends = Friend.objects.filter(username=user)
+            if not friends.exists():
+                return Response(status=status.HTTP_204_NO_CONTENT)
+            
+            friends_data = []
+            for friend in friends:
+                friend_user = friend.friendname
+                matches = Match.objects.filter((Q(match_username1=friend_user) | Q(match_username2=friend_user)) & ~Q(match_result='pending_result'))
+                friends_data.append(
+                    {
+                        "username": friend_user.username,
+                        "status_msg": friend_user.status_msg,
+                        "status": friend_user.status,
+                        "exp": friend_user.exp,
+                        "win_cnt": friend_user.win_cnt,
+                        "lose_cnt": friend_user.lose_cnt,
+                        "profile_img": friend_user.profile_img,
+                        "matches": [
+                            {
+                                'user1_name': match.match_username1.username,
+                                'user2_name': match.match_username2.username,
+                                'user1_profile_img': match.match_username1.profile_img,
+                                'user2_profile_img': match.match_username2.profile_img,
+                                'match_result': match.match_result,
+                                'match_start_time': match.match_start_time,
+                                'match_end_time': match.match_end_time,
+                                'user1_grade': match.username1_grade,
+                                'user2_grade': match.username2_grade,
+                                'match_type': match.match_type
+                            } 
+                            for match in matches.order_by('-match_end_time')[:5]
+                        ]
+                    }
+                )
+            return Response(friends_data, status=status.HTTP_200_OK)
         except ValueError as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
         except PermissionError as e:


### PR DESCRIPTION
## 추가사항
- 친구의 match-history 를 조회시 backend 에서 api 요청을 통해 처리할 수 있도록 구현했습니다.

## 유의사항
- 해당 api 는 현재 완전하게 구현되지 않았습니다.
- 기존 users/friend/self api 와 비슷하게 동작합니다.
- 에러처리가 완전하지 않으니 참고하셔서 사용하시길 바랍니다.
- 현재 API 문서에서는 request 에 아무것도 없을수 있습니다 / 하지만 users/friend/self 홰당 데이터를 꼭 담아서 보내주세요!

## 사용방법
- users/friend/self 로 받아오는 모든 데이터를 해당 api 의 request body 애 넣어주세요
- 보낸 data 에서 match_history 가 붙은 형태의 정보를 받아올 수 있습니다.